### PR TITLE
Thread-safe data init & prevent duplicate tick listeners

### DIFF
--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/LevelMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/LevelMixin.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Mixin(Level.class)
 public abstract class LevelMixin implements TrackedDataContainer<Level, LevelTrackedData>, InternalDirtyMarker, LevelAccessor {
@@ -42,20 +43,20 @@ public abstract class LevelMixin implements TrackedDataContainer<Level, LevelTra
     @Shadow
     @Final
     public boolean isClientSide;
+
     @Unique
     private TrackedDataContainer<Level, LevelTrackedData> dataAnchor$trackedDataContainer = TrackedDataContainer.makeBasicContainer(TrackedDataRegistries.LEVEL, (Level) (Object) this, isClientSide(), false);
 
     @Unique
-    private final List<TickableTrackedData> dataAnchor$tickableLevelData = new ArrayList<>();
+    private final List<TickableTrackedData> dataAnchor$tickableLevelData = new CopyOnWriteArrayList<>();
 
     @Unique
-    private boolean dataAnchor$lazyLoadedTrackedData = false;
+    private volatile boolean dataAnchor$lazyLoadedTrackedData = false;
 
     @Override
     public <E extends LevelTrackedData> Optional<E> dataAnchor$getTrackedData(TrackedDataKey<E> key) {
         if (!dataAnchor$lazyLoadedTrackedData) {
-            dataAnchor$createTrackedData();
-            dataAnchor$lazyLoadedTrackedData = true;
+            dataAnchor$ensureInitialized();
         }
 
         return this.dataAnchor$trackedDataContainer.dataAnchor$getTrackedData(key);
@@ -69,20 +70,31 @@ public abstract class LevelMixin implements TrackedDataContainer<Level, LevelTra
             this.dataAnchor$trackedDataContainer.dataAnchor$createTrackedData();
         }
 
+        this.dataAnchor$tickableLevelData.clear();
+
         for (TrackedDataKey<LevelTrackedData> key : this.dataAnchor$trackedDataContainer.dataAnchor$getTrackedDataKeys()) {
             this.dataAnchor$trackedDataContainer.dataAnchor$getTrackedData(key).ifPresent(levelTrackedData -> {
                 if (levelTrackedData instanceof TickableTrackedData tickableData) {
-                    this.dataAnchor$tickableLevelData.add(tickableData);
+                    if (!this.dataAnchor$tickableLevelData.contains(tickableData)) {
+                        this.dataAnchor$tickableLevelData.add(tickableData);
+                    }
                 }
             });
+        }
+    }
+
+    @Unique
+    private synchronized void dataAnchor$ensureInitialized() {
+        if (!dataAnchor$lazyLoadedTrackedData) {
+            dataAnchor$createTrackedData();
+            dataAnchor$lazyLoadedTrackedData = true;
         }
     }
 
     @Override
     public Collection<TrackedDataKey<LevelTrackedData>> dataAnchor$getTrackedDataKeys() {
         if (!dataAnchor$lazyLoadedTrackedData) {
-            dataAnchor$createTrackedData();
-            dataAnchor$lazyLoadedTrackedData = true;
+            dataAnchor$ensureInitialized();
         }
         return this.dataAnchor$trackedDataContainer.dataAnchor$getTrackedDataKeys();
     }


### PR DESCRIPTION
- Added synchronized init and .contains() checks to ensure createTrackedData runs only once.
- Marked the init flag as volatile to keep state synced.
- Switched tickableLevelData to CopyOnWriteArrayList to prevent ConcurrentModificationException crash.

This fixes both some crashes occurring with Via Romana while charting as well as TPS issues when both Via Romana and Enhanced Celestials are installed.

Here's a before and after in 1.20.1 Fabric with both Via Romana and Enhanced Celestials loaded
<img width="563" height="349" alt="image" src="https://github.com/user-attachments/assets/14d1764a-0997-40d5-8618-5b2ca0c287a0" />

