### PR TITLE
Tracked block entity performance patch

### DIFF
--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/LevelChunkMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/LevelChunkMixin.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025 Corgi Taco.
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package dev.corgitaco.dataanchor.mixin;
+
+import dev.corgitaco.dataanchor.data.TickableTrackedData;
+import dev.corgitaco.dataanchor.data.TrackedDataContainer;
+import dev.corgitaco.dataanchor.data.registry.TrackedDataKey;
+import dev.corgitaco.dataanchor.data.type.blockentity.BlockEntityTrackedData;
+import dev.corgitaco.dataanchor.util.TickableBlockEntityAccessor;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Mixin(LevelChunk.class)
+public class LevelChunkMixin implements TickableBlockEntityAccessor {
+
+    @Unique
+    private final List<BlockEntity> dataAnchor$tickableBlockEntities = new ArrayList<>();
+
+    @Override
+    public List<BlockEntity> dataAnchor$getTickableBlockEntities() {
+        return dataAnchor$tickableBlockEntities;
+    }
+
+    @Inject(method = "setBlockEntity", at = @At("HEAD"))
+    private void dataAnchor$onSetBlockEntityHead(BlockEntity blockEntity, CallbackInfo ci) {
+        BlockEntity oldBlockEntity = ((LevelChunk) (Object) this).getBlockEntity(blockEntity.getBlockPos());
+        if (oldBlockEntity != null) {
+            synchronized (dataAnchor$tickableBlockEntities) {
+                dataAnchor$tickableBlockEntities.remove(oldBlockEntity);
+            }
+        }
+    }
+
+    @Inject(method = "setBlockEntity", at = @At("RETURN"))
+    private void dataAnchor$onSetBlockEntityReturn(BlockEntity blockEntity, CallbackInfo ci) {
+        dataAnchor$checkAndAdd(blockEntity);
+    }
+
+    @Unique
+    private void dataAnchor$checkAndAdd(BlockEntity blockEntity) {
+        if (blockEntity instanceof TrackedDataContainer access) {
+            access.dataAnchor$createTrackedData();
+
+            Collection<TrackedDataKey<BlockEntityTrackedData>> keys = access.dataAnchor$getTrackedDataKeys();
+            if (keys.isEmpty()) return;
+
+            boolean isTickable = false;
+            for (TrackedDataKey<BlockEntityTrackedData> key : keys) {
+                if (access.dataAnchor$getTrackedData(key).orElse(null) instanceof TickableTrackedData) {
+                    isTickable = true;
+                    break;
+                }
+            }
+
+            if (isTickable) {
+                synchronized (dataAnchor$tickableBlockEntities) {
+                    if (!dataAnchor$tickableBlockEntities.contains(blockEntity)) {
+                        dataAnchor$tickableBlockEntities.add(blockEntity);
+                    }
+                }
+            }
+        }
+    }
+
+    @Inject(method = "removeBlockEntity", at = @At("HEAD"))
+    private void dataAnchor$onRemoveBlockEntity(BlockPos pos, CallbackInfo ci) {
+        BlockEntity blockEntity = ((LevelChunk) (Object) this).getBlockEntity(pos);
+        if (blockEntity != null) {
+            synchronized (dataAnchor$tickableBlockEntities) {
+                dataAnchor$tickableBlockEntities.remove(blockEntity);
+            }
+        }
+    }
+}

--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/ServerLevelMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/ServerLevelMixin.java
@@ -17,6 +17,7 @@ import dev.corgitaco.dataanchor.data.type.entity.PlayerTrackedData;
 import dev.corgitaco.dataanchor.data.type.entity.SyncedPlayerTrackedData;
 import dev.corgitaco.dataanchor.data.type.level.LevelTrackedData;
 import dev.corgitaco.dataanchor.data.type.level.SyncedLevelTrackedData;
+import dev.corgitaco.dataanchor.util.TickableBlockEntityAccessor;
 import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceKey;
@@ -36,6 +37,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Supplier;
 
 @Mixin(ServerLevel.class)
@@ -49,6 +51,7 @@ public abstract class ServerLevelMixin extends Level {
     private void dataAnchor$onTickChunk(LevelChunk chunk, int randomTickSpeed, CallbackInfo ci) {
         if (chunk instanceof TrackedDataContainer access) {
             Collection<TrackedDataKey<ChunkTrackedData>> keys = access.dataAnchor$getTrackedDataKeys();
+
             for (TrackedDataKey<ChunkTrackedData> key : keys) {
                 access.dataAnchor$getTrackedData(key).ifPresent(data -> {
                     if (data instanceof TickableTrackedData tickableData) {
@@ -59,21 +62,25 @@ public abstract class ServerLevelMixin extends Level {
         }
 
         if (chunk.getFullStatus().isOrAfter(FullChunkStatus.BLOCK_TICKING)) {
-            for (BlockEntity value : chunk.getBlockEntities().values()) {
-                if (value instanceof TrackedDataContainer access) {
-                    Collection<TrackedDataKey<BlockEntityTrackedData>> keys = access.dataAnchor$getTrackedDataKeys();
-                    for (TrackedDataKey<BlockEntityTrackedData> key : keys) {
-                        access.dataAnchor$getTrackedData(key).ifPresent(data -> {
-                            if (data instanceof TickableTrackedData tickableData) {
-                                tickableData.tick();
-                            }
-                        });
+            if (chunk instanceof TickableBlockEntityAccessor accessor) {
+                List<BlockEntity> tickables = accessor.dataAnchor$getTickableBlockEntities();
+
+                for (BlockEntity value : tickables) {
+                    if (value instanceof TrackedDataContainer access) {
+                        Collection<TrackedDataKey<BlockEntityTrackedData>> keys = access.dataAnchor$getTrackedDataKeys();
+
+                        for (TrackedDataKey<BlockEntityTrackedData> key : keys) {
+                            access.dataAnchor$getTrackedData(key).ifPresent(data -> {
+                                if (data instanceof TickableTrackedData tickableData) {
+                                    tickableData.tick();
+                                }
+                            });
+                        }
                     }
                 }
             }
         }
     }
-
 
     @Inject(method = "addRespawnedPlayer", at = @At("RETURN"))
     private void dataAnchor$addRespawnTeleport(ServerPlayer player, CallbackInfo ci) {

--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/client/LevelMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/client/LevelMixin.java
@@ -13,6 +13,7 @@ import dev.corgitaco.dataanchor.data.TrackedDataContainer;
 import dev.corgitaco.dataanchor.data.registry.TrackedDataKey;
 import dev.corgitaco.dataanchor.data.type.blockentity.BlockEntityTrackedData;
 import dev.corgitaco.dataanchor.data.type.chunk.ChunkTrackedData;
+import dev.corgitaco.dataanchor.util.TickableBlockEntityAccessor;
 import net.minecraft.client.multiplayer.ClientChunkCache;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
@@ -27,12 +28,12 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 @Mixin(Level.class)
 public abstract class LevelMixin implements LevelAccessor {
-
 
     @Shadow
     @Final
@@ -53,24 +54,28 @@ public abstract class LevelMixin implements LevelAccessor {
                         Collection<TrackedDataKey<ChunkTrackedData>> keys = dataContainer.dataAnchor$getTrackedDataKeys();
 
                         for (TrackedDataKey<ChunkTrackedData> key : keys) {
-                            Optional optional = dataContainer.dataAnchor$getTrackedData(key);
-                            if (optional.isPresent()) {
-                                if (optional.get() instanceof TickableTrackedData trackedData) {
-                                    trackedData.tick();
+                            dataContainer.dataAnchor$getTrackedData(key).ifPresent(data -> {
+                                if (data instanceof TickableTrackedData tickableData) {
+                                    tickableData.tick();
                                 }
-                            }
+                            });
                         }
                     }
 
-                    for (BlockEntity value : levelChunk.getBlockEntities().values()) {
-                        if (value instanceof TrackedDataContainer container) {
-                            Collection<TrackedDataKey<BlockEntityTrackedData>> keys = container.dataAnchor$getTrackedDataKeys();
-                            for (TrackedDataKey<BlockEntityTrackedData> key : keys) {
-                                container.dataAnchor$getTrackedData(key).ifPresent(data -> {
-                                    if (data instanceof TickableTrackedData tickableData) {
-                                        tickableData.tick();
-                                    }
-                                });
+                    if (levelChunk instanceof TickableBlockEntityAccessor accessor) {
+                        List<BlockEntity> tickables = accessor.dataAnchor$getTickableBlockEntities();
+
+                        for (BlockEntity value : tickables) {
+                            if (value instanceof TrackedDataContainer dataContainer) {
+                                Collection<TrackedDataKey<BlockEntityTrackedData>> keys = dataContainer.dataAnchor$getTrackedDataKeys();
+
+                                for (TrackedDataKey<BlockEntityTrackedData> key : keys) {
+                                    dataContainer.dataAnchor$getTrackedData(key).ifPresent(data -> {
+                                        if (data instanceof TickableTrackedData tickableData) {
+                                            tickableData.tick();
+                                        }
+                                    });
+                                }
                             }
                         }
                     }

--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/client/LevelMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/client/LevelMixin.java
@@ -85,7 +85,7 @@ public abstract class LevelMixin implements LevelAccessor {
     }
 
     @Unique
-    private synchronized AtomicReferenceArray<LevelChunk> dataAnchor$getChunks(ClientChunkCache clientChunkCache) {
+    private AtomicReferenceArray<LevelChunk> dataAnchor$getChunks(ClientChunkCache clientChunkCache) {
         return clientChunkCache.storage.chunks;
     }
 }

--- a/common/src/main/java/dev/corgitaco/dataanchor/util/TickableBlockEntityAccessor.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/util/TickableBlockEntityAccessor.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Corgi Taco.
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package dev.corgitaco.dataanchor.util;
+
+import net.minecraft.world.level.block.entity.BlockEntity;
+import java.util.List;
+
+public interface TickableBlockEntityAccessor {
+    List<BlockEntity> dataAnchor$getTickableBlockEntities();
+}

--- a/common/src/main/java/dev/corgitaco/dataanchor/util/TickableBlockEntityAccessor.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/util/TickableBlockEntityAccessor.java
@@ -9,8 +9,12 @@
 package dev.corgitaco.dataanchor.util;
 
 import net.minecraft.world.level.block.entity.BlockEntity;
+
+import java.util.Collections;
 import java.util.List;
 
 public interface TickableBlockEntityAccessor {
-    List<BlockEntity> dataAnchor$getTickableBlockEntities();
+    default List<BlockEntity> dataAnchor$getTickableBlockEntities() {
+        return Collections.emptyList();
+    }
 }

--- a/common/src/main/resources/dataanchor-common.mixins.json
+++ b/common/src/main/resources/dataanchor-common.mixins.json
@@ -10,13 +10,14 @@
     "BlockEntityMixin",
     "ChunkAccessMixin",
     "ChunkMapMixin",
+    "ChunkMixin",
     "ChunkSerializerMixin",
     "EntityMixin",
+    "LevelChunkMixin",
     "LevelMixin",
-    "ChunkMixin",
+    "PlayerListMixin",
     "ServerEntityMixin",
-    "ServerLevelMixin",
-    "PlayerListMixin"
+    "ServerLevelMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Added TickableBlockEntityAccessor and LevelChunkMixin to track and tick only block entities with tracked data on both server and client chunk ticks, then updated ServerLevelMixin and LevelMixin to use it.

### Before/After:
<img width="858" height="288" alt="image" src="https://github.com/user-attachments/assets/ec09d755-4e50-455b-9f46-383470212bf2" />
3x3 chunk region of barrels for testing worst-case scenario, real-world server testing showed a drop of ~5% to TPS in a modpack with many block entities placed before this fix.

### Notes:
Ideally a map should be used instead of a list for tracked block entity lookup, but since the vast majority of performance costs came from just checking if each block entity had tracked data I figured it was overkill (for now anyways).