### PR TITLE
Resolve pre-26.1 parity, initialization crash, and chunk-loading error

### DIFF
--- a/common/src/main/java/dev/corgitaco/dataanchor/data/TrackedDataContainer.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/data/TrackedDataContainer.java
@@ -53,6 +53,7 @@ public interface TrackedDataContainer<O, T extends TrackedData<O>> {
             @Override
             public void dataAnchor$createTrackedData() {
                 registry.factories().forEach((key, factory) -> {
+                    if (trackedDataMap.containsKey(key)) return;
                     T trackedData = factory.create(key, o);
                     if (trackedData != null) {
                         if (isClient) {

--- a/common/src/main/java/dev/corgitaco/dataanchor/data/registry/TrackedDataRegistries.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/data/registry/TrackedDataRegistries.java
@@ -8,19 +8,23 @@
 
 package dev.corgitaco.dataanchor.data.registry;
 
-import dev.corgitaco.dataanchor.DataAnchor;
 import dev.corgitaco.dataanchor.data.type.blockentity.BlockEntityTrackedData;
 import dev.corgitaco.dataanchor.data.type.chunk.ChunkTrackedData;
 import dev.corgitaco.dataanchor.data.type.entity.EntityTrackedData;
 import dev.corgitaco.dataanchor.data.type.level.LevelTrackedData;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.ChunkAccess;
 
 public class TrackedDataRegistries {
-    public static final TrackedDataRegistry<Entity, EntityTrackedData> ENTITY = TrackedDataRegistry.of(DataAnchor.id("entity"));
-    public static final TrackedDataRegistry<BlockEntity, BlockEntityTrackedData> BLOCK_ENTITY = TrackedDataRegistry.of(DataAnchor.id("block_entity"));
-    public static final TrackedDataRegistry<ChunkAccess, ChunkTrackedData> CHUNK = TrackedDataRegistry.of(DataAnchor.id("chunk"));
-    public static final TrackedDataRegistry<Level, LevelTrackedData> LEVEL = TrackedDataRegistry.of(DataAnchor.id("level"));
+    public static final TrackedDataRegistry<Entity, EntityTrackedData> ENTITY = TrackedDataRegistry.of(id("entity"));
+    public static final TrackedDataRegistry<BlockEntity, BlockEntityTrackedData> BLOCK_ENTITY = TrackedDataRegistry.of(id("block_entity"));
+    public static final TrackedDataRegistry<ChunkAccess, ChunkTrackedData> CHUNK = TrackedDataRegistry.of(id("chunk"));
+    public static final TrackedDataRegistry<Level, LevelTrackedData> LEVEL = TrackedDataRegistry.of(id("level"));
+
+    private static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath("dataanchor", path);
+    }
 }

--- a/common/src/main/java/dev/corgitaco/dataanchor/data/type/level/TrackedLevelSavedData.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/data/type/level/TrackedLevelSavedData.java
@@ -71,10 +71,10 @@ public class TrackedLevelSavedData extends SavedData implements TrackedDataConta
     public TrackedLevelSavedData init(ServerLevel serverLevel) {
         this.serverLevel = serverLevel;
         dataAnchor$createTrackedData();
-        for (Map.Entry<TrackedDataKey<LevelTrackedData>, LevelTrackedData> entry : trackedDataMap.entrySet()) {
-            String idString = entry.getKey().getId().toString();
-            if (tag.contains(idString)) {
-                entry.getValue().load(tag.getCompound(idString).orElseThrow());
+        if (tag != null) {
+            for (Map.Entry<TrackedDataKey<LevelTrackedData>, LevelTrackedData> entry : trackedDataMap.entrySet()) {
+                String idString = entry.getKey().getId().toString();
+                tag.getCompound(idString).ifPresent(entry.getValue()::load);
             }
         }
         this.tag = null;
@@ -105,6 +105,7 @@ public class TrackedLevelSavedData extends SavedData implements TrackedDataConta
     @Override
     public void dataAnchor$createTrackedData() {
         TrackedDataRegistries.LEVEL.factories().forEach((key, factory) -> {
+            if (trackedDataMap.containsKey(key)) return;
             LevelTrackedData trackedData = factory.create(key, this.serverLevel);
             if (trackedData instanceof ServerTrackedData) {
                 if (trackedData instanceof TickableTrackedData tickableData) {

--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/BlockEntityMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/BlockEntityMixin.java
@@ -76,15 +76,13 @@ public class BlockEntityMixin implements TrackedDataContainer<BlockEntity, Block
         if (cir.getReturnValue() instanceof TrackedDataContainer container) {
             container.dataAnchor$createTrackedData();
             if (tag.contains("TrackedData")) {
-                CompoundTag trackedData = tag.getCompound("TrackedData").orElseThrow();
+                CompoundTag trackedData = tag.getCompound("TrackedData").orElse(new CompoundTag());
                 Collection<TrackedDataKey<BlockEntityTrackedData>> keys = container.dataAnchor$getTrackedDataKeys();
                 for (TrackedDataKey<BlockEntityTrackedData> key : keys) {
                     container.dataAnchor$getTrackedData(key).ifPresent(data -> {
                         if (data instanceof BlockEntityTrackedData blockEntityTrackedData) {
                             String idString = key.getId().toString();
-                            if (trackedData.contains(idString)) {
-                                blockEntityTrackedData.load(trackedData.getCompound(idString).orElseThrow());
-                            }
+                            trackedData.getCompound(idString).ifPresent(blockEntityTrackedData::load);
                         }
                     });
                 }

--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/ChunkSerializerMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/ChunkSerializerMixin.java
@@ -67,14 +67,12 @@ public class ChunkSerializerMixin {
         }
 
         if (returnValue instanceof TrackedDataContainer<?, ?> trackedDataContainer) {
-            CompoundTag trackedDataTag = this.structureData.getCompound("TrackedData").orElseThrow();
+            CompoundTag trackedDataTag = this.structureData.getCompound("TrackedData").orElse(new CompoundTag());
             for (TrackedDataKey key : trackedDataContainer.dataAnchor$getTrackedDataKeys()) {
                 trackedDataContainer.dataAnchor$getTrackedData(key).ifPresent(trackedData -> {
                     if (trackedData instanceof ChunkTrackedData chunkTrackedData) {
                         String idString = key.getId().toString();
-                        if (trackedDataTag.contains(idString)) {
-                            chunkTrackedData.load(trackedDataTag.getCompound(idString).orElseThrow());
-                        }
+                        trackedDataTag.getCompound(idString).ifPresent(chunkTrackedData::load);
                     }
                 });
             }

--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/EntityMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/EntityMixin.java
@@ -75,13 +75,11 @@ public abstract class EntityMixin implements TrackedDataContainer<Entity, Entity
             CompoundTag loadTag = input1.input;
             if (loadTag != null) {
                 if (loadTag.contains("TrackedData")) {
-                    CompoundTag trackedData = loadTag.getCompound("TrackedData").orElseThrow();
+                    CompoundTag trackedData = loadTag.getCompound("TrackedData").orElse(new CompoundTag());
                     Collection<TrackedDataKey<EntityTrackedData>> keys = this.dataAnchor$container.dataAnchor$getTrackedDataKeys();
                     for (TrackedDataKey<EntityTrackedData> key : keys) {
                         String tagKey = key.getId().toString();
-                        if (trackedData.contains(tagKey)) {
-                            this.dataAnchor$container.dataAnchor$getTrackedData(key).ifPresent(entityTrackedData -> entityTrackedData.load(trackedData.getCompound(tagKey).orElseThrow()));
-                        }
+                        trackedData.getCompound(tagKey).ifPresent(tag -> this.dataAnchor$container.dataAnchor$getTrackedData(key).ifPresent(entityTrackedData -> entityTrackedData.load(tag)));
                     }
                 }
             }

--- a/common/src/main/java/dev/corgitaco/dataanchor/mixin/LevelMixin.java
+++ b/common/src/main/java/dev/corgitaco/dataanchor/mixin/LevelMixin.java
@@ -66,7 +66,7 @@ public abstract class LevelMixin implements TrackedDataContainer<Level, LevelTra
     @Override
     public void dataAnchor$createTrackedData() {
         if ((Object) this instanceof ServerLevel serverLevel) {
-            this.dataAnchor$trackedDataContainer = serverLevel.getDataStorage().get(TrackedLevelSavedData.TYPE).init(serverLevel);
+            this.dataAnchor$trackedDataContainer = serverLevel.getDataStorage().computeIfAbsent(TrackedLevelSavedData.TYPE).init(serverLevel);
         } else {
             this.dataAnchor$trackedDataContainer.dataAnchor$createTrackedData();
         }

--- a/fabric/src/main/java/dev/corgitaco/dataanchor/fabric/network/C2SFabricPacketBroadcaster.java
+++ b/fabric/src/main/java/dev/corgitaco/dataanchor/fabric/network/C2SFabricPacketBroadcaster.java
@@ -28,7 +28,7 @@ public class C2SFabricPacketBroadcaster extends FabricPacketBroadcaster implemen
 
     @Override
     protected <T extends Packet> void registerPayload(CustomPacketPayload.Type<T> type, StreamCodec<RegistryFriendlyByteBuf, T> serializer) {
-        PayloadTypeRegistry.clientboundPlay().register(type, serializer);
+        PayloadTypeRegistry.serverboundPlay().register(type, serializer);
     }
 
     @Override


### PR DESCRIPTION
- Prevent duplicate tracked-data creation during entity and level initialization.
- Make tracked-data loading non-crashing (doesn't address root issues of loading from 1.21.X, but prevents crashes).
- Correct flipped Fabric C2S payload registration.
- Break DataAnchor.java/TrackedDataRegistries.java circular initialization that caused startup crashes.

Primarily resolving this startup crash:
```
Description: Initializing game

java.lang.RuntimeException: Could not execute entrypoint stage 'main' due to errors, provided by 'via_romana' at 'net.rasanovum.viaromana.loaders.fabric.FabricMain'!
        at net.fabricmc.loader.impl.FabricLoaderImpl.lambda$invokeEntrypoints$0(FabricLoaderImpl.java:413)
        at net.fabricmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:33)
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:411)
        at net.fabricmc.loader.impl.game.minecraft.Hooks.startClient(Hooks.java:52)
        at knot//net.minecraft.client.Minecraft.<init>(Minecraft.java:477)
        at knot//net.minecraft.client.main.Main.main(Main.java:232)
        at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
        at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
        at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
        at net.fabricmc.devlaunchinjector.Main.main(Main.java:86)
        Suppressed: java.lang.NoClassDefFoundError: Could not initialize class dev.corgitaco.dataanchor.DataAnchor
                at knot//dev.corgitaco.dataanchor.fabric.DataAnchorFabric.onInitialize(DataAnchorFabric.java:25)
                at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:409)
                ... 7 more
        Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.NullPointerException [in thread "Render thread"]
                at knot//dev.corgitaco.dataanchor.DataAnchor.<clinit>(DataAnchor.java:52)
                at knot//dev.corgitaco.dataanchor.data.registry.TrackedDataRegistries.<clinit>(TrackedDataRegistries.java:22)
                at knot//net.rasanovum.viaromana.init.DataInit.<clinit>(DataInit.java:17)
                at knot//net.rasanovum.viaromana.ViaRomana.initialize(ViaRomana.java:66)
                at knot//net.rasanovum.viaromana.ViaRomana.initialize(ViaRomana.java:58)
                at knot//net.rasanovum.viaromana.loaders.fabric.FabricMain.onInitialize(FabricMain.java:26)
                ... 8 more
Caused by: java.lang.ExceptionInInitializerError
        at knot//dev.corgitaco.dataanchor.data.registry.TrackedDataRegistries.<clinit>(TrackedDataRegistries.java:22)
        at knot//net.rasanovum.viaromana.init.DataInit.<clinit>(DataInit.java:17)
        at knot//net.rasanovum.viaromana.ViaRomana.initialize(ViaRomana.java:66)
        at knot//net.rasanovum.viaromana.ViaRomana.initialize(ViaRomana.java:58)
        at knot//net.rasanovum.viaromana.loaders.fabric.FabricMain.onInitialize(FabricMain.java:26)
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:409)
        ... 7 more
Caused by: java.lang.NullPointerException: Cannot invoke "dev.corgitaco.dataanchor.data.registry.TrackedDataRegistry.register(net.minecraft.resources.Identifier, java.lang.Class, dev.corgitaco.dataanchor.data.registry.TrackedDataRegistry$TrackedDataFactory)" because "dev.corgitaco.dataanchor.data.registry.TrackedDataRegistries.ENTITY" is null
        at knot//dev.corgitaco.dataanchor.DataAnchor.<clinit>(DataAnchor.java:52)
        ... 13 more
```

And this world-loading error on every chunk (from a 1.21.1 world with Data Anchor):
```
java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.orElseThrow(Optional.java:377)
        at knot//net.minecraft.world.level.chunk.storage.SerializableChunkData.handler$zcf000$dataanchor$dataAnchor$read(SerializableChunkData.java:747)
        at knot//net.minecraft.world.level.chunk.storage.SerializableChunkData.read(SerializableChunkData.java:316)
        at knot//net.minecraft.server.level.ChunkMap.lambda$scheduleChunkLoad$3(ChunkMap.java:601)
        at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:667)
        at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:503)
        at knot//net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:173)
        at knot//net.minecraft.server.level.ServerChunkCache$MainThreadExecutor.doRunTask(ServerChunkCache.java:617)
        at knot//net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:147)
        at knot//net.minecraft.server.level.ServerChunkCache$MainThreadExecutor.pollTask(ServerChunkCache.java:626)
        at knot//net.minecraft.server.level.ServerChunkCache.pollTask(ServerChunkCache.java:269)
        at knot//net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:922)
        at knot//net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:910)
        at knot//net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:127)
        at knot//net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:878)
        at knot//net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:780)
        at knot//net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:321)
        at java.base/java.lang.Thread.run(Thread.java:1474)
[10:51:16] [Server thread/ERROR] (Minecraft) Failed to load chunk -15,51

...
```